### PR TITLE
Added support for async `createReadStream`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "node-fetch": "2.1.2",
     "nyc": "11.8.0",
     "request": "2.87.0",
+    "sleep-promise": "6.0.0",
     "test-listen": "1.1.0"
   },
   "eslintConfig": {

--- a/src/index.js
+++ b/src/index.js
@@ -511,7 +511,8 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 	}
 
 	const headers = await getHeaders(config.headers, relativePath, stats);
+	const stream = await handlers.createReadStream(absolutePath);
 
 	response.writeHead(response.statusCode || 200, headers);
-	handlers.createReadStream(absolutePath).pipe(response);
+	stream.pipe(response);
 };

--- a/test/integration.js
+++ b/test/integration.js
@@ -7,6 +7,7 @@ const listen = require('test-listen');
 const micro = require('micro');
 const fetch = require('node-fetch');
 const fs = require('fs-extra');
+const sleep = require('sleep-promise');
 
 // Utilities
 const handler = require('../');
@@ -664,5 +665,24 @@ test('set `unlisted` config property to array', async t => {
 	});
 
 	t.true(existing);
+});
+
+test('set `createReadStream` handler to async function', async t => {
+	const name = '.dotfile';
+	const related = path.join(fixturesFull, name);
+	const content = await fs.readFile(related, 'utf8');
+
+	// eslint-disable-next-line no-undefined
+	const url = await getUrl(undefined, {
+		createReadStream: async file => {
+			await sleep(2000);
+			return fs.createReadStream(file);
+		}
+	});
+
+	const response = await fetch(`${url}/${name}`);
+	const text = await response.text();
+
+	t.deepEqual(content, text);
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3569,6 +3569,10 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
+sleep-promise@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/sleep-promise/-/sleep-promise-6.0.0.tgz#a80b4c3c26ed553c73c9db7234bc0304f7d42d4a"
+
 slice-ansi@1.0.0, slice-ansi@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"


### PR DESCRIPTION
As the `README.md` file states it, we're allowing the `createReadStream` handler to be a promise or asynchronous function (when loading something for a third party source in there, for example).