### PR TITLE
Applied improvements from another round of testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,15 @@ For example, if serving a [Jekyll](https://jekyllrb.com/) app, it would look lik
 
 ### cleanUrls (Boolean|Array)
 
-Assuming this is `true`, all `.html` and `.htm` files can be accessed without their extension (shown below).
+By default, all `.html` and `.htm` files can be accessed without their extension
 
 If one of these extensions is used at the end of a filename, it will automatically perform a redirect with status code [301](https://en.wikipedia.org/wiki/HTTP_301) to the same path, but with the extension dropped.
 
+You can disable the feature like follows:
+
 ```json
 {
-  "cleanUrls": true
+  "cleanUrls": false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For example, if serving a [Jekyll](https://jekyllrb.com/) app, it would look lik
 
 ### cleanUrls (Boolean|Array)
 
-By default, all `.html` and `.htm` files can be accessed without their extension
+By default, all `.html` and `.htm` files can be accessed without their extension.
 
 If one of these extensions is used at the end of a filename, it will automatically perform a redirect with status code [301](https://en.wikipedia.org/wiki/HTTP_301) to the same path, but with the extension dropped.
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You can disable the feature like follows:
 }
 ```
 
-However, you can also restrict this behavior to certain paths:
+However, you can also restrict it to certain paths:
 
 ```json
 {

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ const shouldRedirect = (decodedPath, {redirects = [], trailingSlash}, cleanUrl) 
 	}
 
 	const defaultType = 301;
-	const matchHTML = /.html|.htm|\/index$/g;
+	const matchHTML = /(\.html|\.htm|\/index)$/g;
 
 	let cleanedUrl = false;
 

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ const shouldRedirect = (decodedPath, {redirects = [], trailingSlash}, cleanUrl) 
 	}
 
 	const defaultType = 301;
-	const matchHTML = /.html|.htm|\/index/g;
+	const matchHTML = /.html|.htm|\/index$/g;
 
 	let cleanedUrl = false;
 

--- a/test/fixtures/special-directory/not-an-index.md
+++ b/test/fixtures/special-directory/not-an-index.md
@@ -1,0 +1,1 @@
+# I am yet another markdown file

--- a/test/integration.js
+++ b/test/integration.js
@@ -80,7 +80,7 @@ test('render json directory listing', async t => {
 });
 
 test('render html sub directory listing', async t => {
-	const name = 'directory';
+	const name = 'special-directory';
 
 	const sub = path.join(fixturesFull, name);
 	const contents = await getDirectoryContents(sub, true);
@@ -95,7 +95,7 @@ test('render html sub directory listing', async t => {
 });
 
 test('render json sub directory listing', async t => {
-	const name = 'another-directory';
+	const name = 'special-directory';
 
 	const sub = path.join(fixturesFull, name);
 	const contents = await getDirectoryContents(sub, true);

--- a/test/integration.js
+++ b/test/integration.js
@@ -546,6 +546,25 @@ test('set `cleanUrls` config property to array', async t => {
 	t.is(content, text);
 });
 
+test('set `cleanUrls` config property to empty array', async t => {
+	const name = 'directory';
+
+	const sub = path.join(fixturesFull, name);
+	const contents = await getDirectoryContents(sub, true);
+
+	const url = await getUrl({
+		cleanUrls: []
+	});
+
+	const response = await fetch(`${url}/${name}`);
+	const text = await response.text();
+
+	const type = response.headers.get('content-type');
+	t.is(type, 'text/html; charset=utf-8');
+
+	t.true(contents.every(item => text.includes(item)));
+});
+
 test('set `cleanUrls` config property to `true` and try with file', async t => {
 	const target = '/directory/clean-file';
 


### PR DESCRIPTION
- We've decided that `cleanUrls` should default to `true` (as literally everyone will use that option).
- We're not matching against `/index` for cleaning URLs anymore, because paths could also end with `/index.js`, so we added a `$` for ensuring it's the end of the path.

💅 