### PR TITLE
Fixed rewriting behavior

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,20 +66,23 @@ const toTarget = (source, destination, previousPath) => {
 };
 
 const applyRewrites = (requestPath, rewrites = []) => {
-	if (rewrites.length === 0) {
+	// We need to copy the array, since we're going to modify it
+	const rewritesCopy = rewrites.slice();
+
+	if (rewritesCopy.length === 0) {
 		return requestPath;
 	}
 
-	for (let index = 0; index < rewrites.length; index++) {
+	for (let index = 0; index < rewritesCopy.length; index++) {
 		const {source, destination} = rewrites[index];
 		const target = toTarget(source, destination, requestPath);
 
 		if (target) {
 			// Remove rules that were already applied
-			rewrites.splice(index, 1);
+			rewritesCopy.splice(index, 1);
 
 			// Check if there are remaining ones to be applied
-			return applyRewrites(slasher(target), rewrites);
+			return applyRewrites(slasher(target), rewritesCopy);
 		}
 	}
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -215,6 +215,24 @@ test('set `rewrites` config property to wildcard path', async t => {
 	t.is(text, content);
 });
 
+test('set `rewrites` config property to non-matching path', async t => {
+	const destination = '404.html';
+	const related = path.join(fixturesFull, destination);
+	const content = await fs.readFile(related, 'utf8');
+
+	const url = await getUrl({
+		rewrites: [{
+			source: 'face/**',
+			destination
+		}]
+	});
+
+	const response = await fetch(`${url}/mask/delete`);
+	const text = await response.text();
+
+	t.is(text, content);
+});
+
 test('set `rewrites` config property to one-star wildcard path', async t => {
 	const destination = '.dotfile';
 	const related = path.join(fixturesFull, destination);


### PR DESCRIPTION
Previously, we were modifying the `config.rewrites` array. This led to the first request being rewritten and the requests after that not receiving any effects.

With this PR, we're copying the array, thus resolving the root issue.

Additional, this makes rewrites work like in all other HTTP servers: Instead of rewriting upfront, we only rewrite if the path does not exist on disk.

This closes #10.