### PR TITLE
Fall mime type back to the one of the rewritten path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,7 @@ const appendHeaders = (target, source) => {
 	}
 };
 
-const getHeaders = async (customHeaders = [], relativePath, stats) => {
+const getHeaders = async (customHeaders = [], relativePath, rewrittenPath, stats) => {
 	const related = {};
 
 	if (customHeaders.length > 0) {
@@ -187,7 +187,7 @@ const getHeaders = async (customHeaders = [], relativePath, stats) => {
 	}
 
 	const defaultHeaders = {
-		'Content-Type': mime.getType(relativePath),
+		'Content-Type': mime.getType(relativePath) || mime.getType(rewrittenPath),
 		'Last-Modified': stats.mtime.toUTCString(),
 		'Content-Length': stats.size
 	};
@@ -520,7 +520,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 		relativePath = errorPage;
 	}
 
-	const headers = await getHeaders(config.headers, relativePath, stats);
+	const headers = await getHeaders(config.headers, relativePath, rewrittenPath, stats);
 	const stream = await handlers.createReadStream(absolutePath);
 
 	response.writeHead(response.statusCode || 200, headers);

--- a/test/integration.js
+++ b/test/integration.js
@@ -723,3 +723,16 @@ test('set `createReadStream` handler to async function', async t => {
 	t.deepEqual(content, text);
 });
 
+test('return mime type of the `rewrittenPath` if mime type of `relativePath` is null', async t => {
+	const url = await getUrl({
+		rewrites: [{
+			source: '**',
+			destination: 'clean-file.html'
+		}]
+	});
+
+	const response = await fetch(`${url}/whatever`);
+	const type = response.headers.get('content-type');
+
+	t.is(type, 'text/html');
+});


### PR DESCRIPTION
In some case, the `content-type` response return for serve is `null`
For example when using **serve** with  `--single` flag, the content-type of `/whatever` would be null instead of `text/html`

This pull request fixes just that.
