### PR TITLE
Added default `Content-Disposition` header

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "dependencies": {
     "bytes": "3.0.0",
+    "content-disposition": "0.5.2",
     "fast-url-parser": "1.1.3",
     "glob-slasher": "1.0.1",
     "mime-types": "2.1.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,6 +1076,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
+content-disposition@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
+
 content-type@1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"


### PR DESCRIPTION
This PR adds a new feature to the package: A default for the `Content-Disposition` header, which is responsible for deciding whether an asset should be downloaded or displayed within the browser.

We never had this in `serve` before, but since our static deployments on Now are also sending this header, we need it to become fully compatible. Aside from that, it's just a great default to have and can be overridden at any time using the `headers` config property.