### PR TITLE
Center directory listing on wide screens

### DIFF
--- a/src/directory.jst
+++ b/src/directory.jst
@@ -17,6 +17,7 @@
 
 		main {
 		  max-width: 920px;
+		  margin: auto;
 		}
 
 		header {


### PR DESCRIPTION
On wide screens, the serve directory listing is left-aligned. This leaves the hamburger menu in an awkward position.

This PR centers the directory listing.

Before:

<img width="1440" alt="screen shot 2018-06-03 at 8 34 16 pm" src="https://user-images.githubusercontent.com/1485350/40897052-9bfa7aa8-676d-11e8-9259-e80b55b9c32a.png">

After:

<img width="1440" alt="screen shot 2018-06-03 at 8 34 34 pm" src="https://user-images.githubusercontent.com/1485350/40897053-9d55d24e-676d-11e8-8204-8851bb75be11.png">

Please feel free to deny if this was a deliberate design choice.