### PR TITLE
Make `cleanUrls` stop stripping `.htm` extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can use any of the following options:
 | Property                                             | Description                                               |
 |------------------------------------------------------|-----------------------------------------------------------|
 | [`public`](#public-boolean)                          | Set a sub directory to be served                          |
-| [`cleanUrls`](#cleanurls-booleanarray)               | Have `.html` and `.htm` extension stripped from paths     |
+| [`cleanUrls`](#cleanurls-booleanarray)               | Have the `.html` extension stripped from paths            |
 | [`rewrites`](#rewrites-array)                        | Rewrite paths to different paths                          |
 | [`redirects`](#redirects-array)                      | Forward paths to different paths or external URLs         |
 | [`headers`](#headers-array)                          | Set custom headers for specific paths                     |
@@ -73,7 +73,7 @@ For example, if serving a [Jekyll](https://jekyllrb.com/) app, it would look lik
 
 ### cleanUrls (Boolean|Array)
 
-By default, all `.html` and `.htm` files can be accessed without their extension.
+By default, all `.html` files can be accessed without their extension.
 
 If one of these extensions is used at the end of a filename, it will automatically perform a redirect with status code [301](https://en.wikipedia.org/wiki/HTTP_301) to the same path, but with the extension dropped.
 

--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ const shouldRedirect = (decodedPath, {redirects = [], trailingSlash}, cleanUrl) 
 	}
 
 	const defaultType = 301;
-	const matchHTML = /(\.html|\.htm|\/index)$/g;
+	const matchHTML = /(\.html|\/index)$/g;
 
 	let cleanedUrl = false;
 
@@ -235,8 +235,8 @@ const getPossiblePaths = (relativePath, extension) => [
 	relativePath.endsWith('/') ? relativePath.replace(/\/$/g, extension) : (relativePath + extension)
 ];
 
-const findRelated = async (current, relativePath, rewrittenPath, originalStat, extension = '.html') => {
-	const possible = rewrittenPath ? [rewrittenPath] : getPossiblePaths(relativePath, extension);
+const findRelated = async (current, relativePath, rewrittenPath, originalStat) => {
+	const possible = rewrittenPath ? [rewrittenPath] : getPossiblePaths(relativePath, '.html');
 
 	let stats = null;
 
@@ -260,13 +260,7 @@ const findRelated = async (current, relativePath, rewrittenPath, originalStat, e
 		}
 	}
 
-	if (extension === '.htm') {
-		return null;
-	}
-
-	// At this point, no `.html` files have been found, so we
-	// need to check for the existance of `.htm` ones.
-	return findRelated(current, relativePath, rewrittenPath, originalStat, '.htm');
+	return null;
 };
 
 const canBeListed = (excluded, file) => {

--- a/test/integration.js
+++ b/test/integration.js
@@ -599,21 +599,6 @@ test('set `cleanUrls` config property to `true` and try with file', async t => {
 	t.is(location, `${url}${target}`);
 });
 
-test('set `cleanUrls` config property to `true` and render `.htm` file', async t => {
-	const target = 'another-directory';
-	const index = path.join(fixturesFull, target, 'index.htm');
-
-	const url = await getUrl({
-		cleanUrls: true
-	});
-
-	const response = await fetch(`${url}/${target}`);
-	const content = await fs.readFile(index, 'utf8');
-	const text = await response.text();
-
-	t.is(content, text);
-});
-
 test('set `cleanUrls` config property to `true` and not index file found', async t => {
 	const contents = await getDirectoryContents();
 	const url = await getUrl({cleanUrls: true});


### PR DESCRIPTION
This is necessary as we need the library to make less stat calls for production. Aside from that `.htm` is just a very odd extension that most people don't use (there's also no good reason to not use `.html`).