### PR TITLE
Reduce number of stat calls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -440,7 +440,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 
 	// It's extremely important that we're doing multiple stat calls. This one
 	// right here could technically be removed, but then the program
-	// would be slower. Cause for directories, we always wanna see if a related file
+	// would be slower. Because for directories, we always wanna see if a related file
 	// exists and then (after that), fetch the directory itself if no
 	// related file was found. However (for files, of which most have extensions), we should
 	// always stat right away.

--- a/src/index.js
+++ b/src/index.js
@@ -278,7 +278,7 @@ const canBeListed = (excluded, file) => {
 	return whether;
 };
 
-const renderDirectory = async (current, acceptsJSON, handlers, config, paths) => {
+const renderDirectory = async (current, acceptsJSON, handlers, methods, config, paths) => {
 	const {directoryListing, trailingSlash, unlisted = []} = config;
 	const slashSuffix = typeof trailingSlash === 'boolean' ? (trailingSlash ? '/' : '') : '/';
 	const {relativePath, absolutePath} = paths;
@@ -306,7 +306,7 @@ const renderDirectory = async (current, acceptsJSON, handlers, config, paths) =>
 		// simulating those calls and needs to special-case this.
 		let stats = null;
 
-		if (config.handlers && config.handlers.stat) {
+		if (methods.stat) {
 			stats = await handlers.stat(filePath, true);
 		} else {
 			stats = await handlers.stat(filePath);
@@ -488,7 +488,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 		let directory = null;
 
 		try {
-			directory = await renderDirectory(current, acceptsJSON, handlers, config, {
+			directory = await renderDirectory(current, acceptsJSON, handlers, methods, config, {
 				relativePath,
 				absolutePath
 			});

--- a/src/index.js
+++ b/src/index.js
@@ -232,7 +232,7 @@ const applicable = (decodedPath, configEntry) => {
 const getPossiblePaths = (relativePath, extension) => [
 	path.join(relativePath, `index${extension}`),
 	relativePath.endsWith('/') ? relativePath.replace(/\/$/g, extension) : (relativePath + extension)
-];
+].filter(item => path.basename(item) !== extension);
 
 const findRelated = async (current, relativePath, rewrittenPath, originalStat) => {
 	const possible = rewrittenPath ? [rewrittenPath] : getPossiblePaths(relativePath, '.html');

--- a/src/index.js
+++ b/src/index.js
@@ -301,7 +301,11 @@ const renderDirectory = async (current, acceptsJSON, handlers, config, paths) =>
 
 		const filePath = path.resolve(absolutePath, file);
 		const details = path.parse(filePath);
-		const stats = await handlers.stat(filePath);
+
+		// It's important to indicate that the `stat` call was
+		// spawned by the directory listing, as Now is
+		// simulating those calls and needs to special-case this.
+		const stats = await handlers.stat(filePath, true);
 
 		details.relative = path.join(relativePath, details.base);
 

--- a/src/index.js
+++ b/src/index.js
@@ -440,7 +440,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 
 	// It's extremely important that we're doing multiple stat calls. This one
 	// right here could technically be removed, but then the program
-	// would be slower. Because for directories, we always wanna see if a related file
+	// would be slower. Because for directories, we always want to see if a related file
 	// exists and then (after that), fetch the directory itself if no
 	// related file was found. However (for files, of which most have extensions), we should
 	// always stat right away.

--- a/test/integration.js
+++ b/test/integration.js
@@ -700,6 +700,40 @@ test('error occurs while getting stat of path', async t => {
 	t.is(text, message);
 });
 
+test('the first `stat` call should be for a related file', async t => {
+	let done = null;
+
+	// eslint-disable-next-line no-undefined
+	const url = await getUrl(undefined, {
+		stat: location => {
+			if (!done) {
+				t.is(path.basename(location), 'index.html');
+				done = true;
+			}
+
+			return fs.stat(location);
+		}
+	});
+
+	await fetch(url);
+});
+
+test('the `stat` call should only be made for files and directories', async t => {
+	const locations = [];
+
+	// eslint-disable-next-line no-undefined
+	const url = await getUrl(undefined, {
+		stat: location => {
+			locations.push(location);
+			return fs.stat(location);
+		}
+	});
+
+	await fetch(url);
+
+	t.falsy(locations.some(location => path.basename(location) === '.html'));
+});
+
 test('error occurs while getting stat of not-found path', async t => {
 	const message = 'This is an error';
 	const base = 'not-existing';

--- a/test/integration.js
+++ b/test/integration.js
@@ -129,7 +129,12 @@ test('render json sub directory listing with custom stat handler', async t => {
 	// eslint-disable-next-line no-undefined
 	const url = await getUrl(undefined, {
 		stat: (location, isDirectoryListing) => {
-			t.true(isDirectoryListing);
+			if (contents.includes(path.basename(location))) {
+				t.true(isDirectoryListing);
+			} else {
+				t.falsy(isDirectoryListing);
+			}
+
 			return fs.stat(location);
 		}
 	});


### PR DESCRIPTION
Previously, the package was firstly checking the existence of the requested path and then seeing if related paths like `<path>/index.html` exist.

However, since directory listings are not the most common use case of this package (but rather rendering files and static projects), I decided to move this further down the line.

As a result, if you request `/`, the first `stat` call will no more be for the directory `/`, but rather for `/index.html`, as long as `cleanUrls` or a respective `rewrites` item is enabled.

---

🎉 **This is not a breaking change, it only reduces the number of `stat` calls to be made until a file is reached and sent back to the client.**

🍏  **I also added 4 more tests, in addition to the existing ones passing. We now have 43!**