### PR TITLE
Added `renderSingle` configuration property

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ You can use any of the following options:
 | [`directoryListing`](#directorylisting-booleanarray) | Disable directory listing or restrict it to certain paths |
 | [`unlisted`](#unlisted-array)                        | Exclude paths from the directory listing                  |
 | [`trailingSlash`](#trailingslash-boolean)            | Remove or add trailing slashes to all paths               |
+| [`renderSingle`](#rendersingle-boolean)              | If a directory only contains one file, render it          |
 
 ### public (String)
 
@@ -230,6 +231,20 @@ By default, the package will try to make assumptions for when to add trailing sl
 ```
 
 With the above config, a request to `/test` would now result in a [301](https://en.wikipedia.org/wiki/HTTP_301) redirect to `/test/`.
+
+### renderSingle (Boolean)
+
+Sometimes you might want to have a directory path actually render a file, if the directory only contains one. This is only useful for any files that are not `.html` files (for those, [`cleanUrls`](#cleanurls-booleanarray) is faster).
+
+This is disabled by default and can be enabled like this:
+
+```js
+{
+  "renderSingle": true
+}
+```
+
+After that, if you access your directory `/test` (for example), you will see an image being rendered if the directory contains a single image file.
 
 ## Middleware
 

--- a/src/index.js
+++ b/src/index.js
@@ -314,14 +314,6 @@ const renderDirectory = async (current, acceptsJSON, handlers, methods, config, 
 			stats = await handlers.stat(filePath);
 		}
 
-		if (canRenderSingle) {
-			return {
-				singleFile: true,
-				absolutePath: filePath,
-				stats
-			};
-		}
-
 		details.relative = path.join(relativePath, details.base);
 
 		if (stats.isDirectory()) {
@@ -329,6 +321,14 @@ const renderDirectory = async (current, acceptsJSON, handlers, methods, config, 
 			details.relative += slashSuffix;
 			details.type = 'directory';
 		} else {
+			if (canRenderSingle) {
+				return {
+					singleFile: true,
+					absolutePath: filePath,
+					stats
+				};
+			}
+
 			details.ext = details.ext.split('.')[1] || 'txt';
 			details.type = 'file';
 

--- a/test/fixtures/single-directory/content.txt
+++ b/test/fixtures/single-directory/content.txt
@@ -1,0 +1,1 @@
+I am a single file

--- a/test/integration.js
+++ b/test/integration.js
@@ -859,3 +859,20 @@ test('error if trying to traverse path', async t => {
 	t.is(response.status, 400);
 	t.is(text, 'Bad Request');
 });
+
+test('render file if directory only contains one', async t => {
+	const directory = 'single-directory';
+	const file = 'content.txt';
+	const related = path.join(fixturesFull, directory, file);
+	const content = await fs.readFile(related, 'utf8');
+
+	const url = await getUrl({
+		renderSingle: true
+	});
+
+	const response = await fetch(`${url}/${directory}`);
+	const text = await response.text();
+
+	t.is(text, content);
+});
+


### PR DESCRIPTION
As described in [the readme](https://github.com/zeit/serve-handler/tree/render-single#rendersingle-boolean), this new property will allow for rendering a file if the directory you're trying to access only contains one single file.

For example: If you have a directory called `/test` with `image.png` inside, then you will see `image.png` be rendered in your browser if you access `/test`.

---

This property is very similar to `cleanUrls`, yet very distinct: It doesn't try to `stat` upfront, but only considers the contents of directories that have been loaded.

I also added a test for this functionality, so we have 46 tests now.