### PR TITLE
Fixed requests to `/index` being redirected wrong

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,6 +95,8 @@ const applyRewrites = (requestPath, rewrites = [], repetitive) => {
 	return fallback;
 };
 
+const ensureSlashStart = target => (target.startsWith('/') ? target : `/${target}`);
+
 const shouldRedirect = (decodedPath, {redirects = [], trailingSlash}, cleanUrl) => {
 	const slashing = typeof trailingSlash === 'boolean';
 	const defaultType = 301;
@@ -134,7 +136,7 @@ const shouldRedirect = (decodedPath, {redirects = [], trailingSlash}, cleanUrl) 
 
 		if (target) {
 			return {
-				target,
+				target: ensureSlashStart(target),
 				statusCode: defaultType
 			};
 		}
@@ -142,7 +144,7 @@ const shouldRedirect = (decodedPath, {redirects = [], trailingSlash}, cleanUrl) 
 
 	if (cleanedUrl) {
 		return {
-			target: decodedPath,
+			target: ensureSlashStart(decodedPath),
 			statusCode: defaultType
 		};
 	}

--- a/test/integration.js
+++ b/test/integration.js
@@ -876,3 +876,16 @@ test('render file if directory only contains one', async t => {
 	t.is(text, content);
 });
 
+test('correctly handle requests to /index if `cleanUrls` is enabled', async t => {
+	const url = await getUrl();
+	const target = `${url}/index`;
+
+	const response = await fetch(target, {
+		redirect: 'manual',
+		follow: 0
+	});
+
+	const location = response.headers.get('location');
+	t.is(location, `${url}/`);
+});
+


### PR DESCRIPTION
Previously, an empty `Location` header was passed. This is now fixed!

This closes https://github.com/zeit/serve/issues/402.