### PR TITLE
fix issues with dots in paths (and with files with no extensions)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -524,8 +524,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 
 	try {
 		stats = await handlers.stat(absolutePath);
-	}
-	catch(err) {
+	} catch(err) {
 		stats = null;
 		if (err.code !== 'ENOENT') {
 			return internalError(response, acceptsJSON, current, handlers, config, err);

--- a/src/index.js
+++ b/src/index.js
@@ -522,47 +522,25 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 
 	let stats = null;
 
-	// It's extremely important that we're doing multiple stat calls. This one
-	// right here could technically be removed, but then the program
-	// would be slower. Because for directories, we always want to see if a related file
-	// exists and then (after that), fetch the directory itself if no
-	// related file was found. However (for files, of which most have extensions), we should
-	// always stat right away.
-	//
-	// When simulating a file system without directory indexes, calculating whether a
-	// directory exists requires loading all the file paths and then checking if
-	// one of them includes the path of the directory. As that's a very
-	// performance-expensive thing to do, we need to ensure it's not happening if not really necessary.
-
-	if (path.extname(absolutePath) !== '') {
-		try {
-			stats = await handlers.stat(absolutePath);
-		} catch (err) {
-			if (err.code !== 'ENOENT') {
-				return internalError(response, acceptsJSON, current, handlers, config, err);
-			}
+	try {
+		stats = await handlers.stat(absolutePath);
+	}
+	catch(err) {
+		stats = null;
+		if (err.code !== 'ENOENT') {
+			return internalError(response, acceptsJSON, current, handlers, config, err);
 		}
 	}
 
 	const rewrittenPath = applyRewrites(relativePath, config.rewrites);
 
-	if (!stats && (cleanUrl || rewrittenPath)) {
+	if ((!stats || stats.isDirectory()) && (cleanUrl || rewrittenPath)) {
 		try {
 			const related = await findRelated(current, relativePath, rewrittenPath, handlers.stat);
 
 			if (related) {
 				({stats, absolutePath} = related);
 			}
-		} catch (err) {
-			if (err.code !== 'ENOENT') {
-				return internalError(response, acceptsJSON, current, handlers, config, err);
-			}
-		}
-	}
-
-	if (!stats) {
-		try {
-			stats = await handlers.stat(absolutePath);
 		} catch (err) {
 			if (err.code !== 'ENOENT') {
 				return internalError(response, acceptsJSON, current, handlers, config, err);

--- a/src/index.js
+++ b/src/index.js
@@ -524,7 +524,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 
 	try {
 		stats = await handlers.stat(absolutePath);
-	} catch(err) {
+	} catch (err) {
 		stats = null;
 		if (err.code !== 'ENOENT') {
 			return internalError(response, acceptsJSON, current, handlers, config, err);


### PR DESCRIPTION
this should resolve https://github.com/zeit/serve/issues/421

I understand that the number of stat calls should be minimized, but it seems like a bad tradeoff to not support dots in paths (which maybe could handled by trying to better parse the absolutePath setting) and without this change, filenames with no extension will also cause issues (at least by my limited reading).

It seems worthwhile to do a stat to discover what we're looking at initially.

One option to mitigate performance issues might be keeping an LRU cache of stat results?