### PR TITLE
Allow dots in value of `public` option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -425,7 +425,8 @@ const renderDirectory = async (current, acceptsJSON, handlers, methods, config, 
 const sendError = async (response, acceptsJSON, current, handlers, config, spec) => {
 	const {err: original, message, code, statusCode} = spec;
 
-	if (original) {
+	/* istanbul ignore next */
+	if (original && process.env.NODE_ENV !== 'test') {
 		console.error(original);
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -534,7 +534,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 	// one of them includes the path of the directory. As that's a very
 	// performance-expensive thing to do, we need to ensure it's not happening if not really necessary.
 
-	if (path.extname(absolutePath) !== '') {
+	if (path.extname(relativePath) !== '') {
 		try {
 			stats = await handlers.stat(absolutePath);
 		} catch (err) {

--- a/test/fixtures/public-folder.test/index.html
+++ b/test/fixtures/public-folder.test/index.html
@@ -1,0 +1,1 @@
+<span>I am a test for a directory with a dot in the name</span>

--- a/test/integration.js
+++ b/test/integration.js
@@ -754,16 +754,23 @@ test('error occurs while getting stat of path', async t => {
 
 	// eslint-disable-next-line no-undefined
 	const url = await getUrl(undefined, {
-		stat: () => {
-			throw new Error(message);
+		stat: location => {
+			if (path.basename(location) !== '500.html') {
+				throw new Error(message);
+			}
 		}
 	});
 
 	const response = await fetch(url);
 	const text = await response.text();
 
+	const content = errorTemplate({
+		statusCode: 500,
+		message: 'A server error has occurred'
+	});
+
 	t.is(response.status, 500);
-	t.is(text, message);
+	t.is(text, content);
 });
 
 test('the first `stat` call should be for a related file', async t => {

--- a/test/integration.js
+++ b/test/integration.js
@@ -932,3 +932,20 @@ test('correctly handle requests to /index if `cleanUrls` is enabled', async t =>
 	t.is(location, `${url}/`);
 });
 
+test('allow dots in `public` configuration property', async t => {
+	const directory = 'public-folder.test';
+	const root = path.join(fixturesTarget, directory);
+	const file = path.join(fixturesFull, directory, 'index.html');
+
+	const url = await getUrl({
+		'public': root,
+		'directoryListing': false
+	});
+
+	const response = await fetch(url);
+	const text = await response.text();
+	const content = await fs.readFile(file, 'utf8');
+
+	t.is(response.status, 200);
+	t.is(content, text);
+});


### PR DESCRIPTION
This fixes https://github.com/zeit/serve/issues/421.

This passes all tests.

It will still have problems with filenames that have no extension, but it addresses not allowing dots in the "public" folder setting.