### PR TITLE
Properly handle requests with malformed URIs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -490,14 +490,25 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 	const cwd = process.cwd();
 	const current = config.public ? path.join(cwd, config.public) : cwd;
 	const handlers = getHandlers(methods);
-	const relativePath = decodeURIComponent(url.parse(request.url).pathname);
 
-	let absolutePath = path.join(current, relativePath);
+	let relativePath = null;
 	let acceptsJSON = null;
 
 	if (request.headers.accept) {
 		acceptsJSON = request.headers.accept.includes('application/json');
 	}
+
+	try {
+		relativePath = decodeURIComponent(url.parse(request.url).pathname);
+	} catch (err) {
+		return sendError(response, acceptsJSON, current, handlers, config, {
+			statusCode: 400,
+			code: 'bad_request',
+			message: 'Bad Request'
+		});
+	}
+
+	let absolutePath = path.join(current, relativePath);
 
 	// Prevent path traversal vulnerabilities. We could do this
 	// by ourselves, but using the package covers all the edge cases.

--- a/test/integration.js
+++ b/test/integration.js
@@ -956,3 +956,19 @@ test('allow dots in `public` configuration property', async t => {
 	t.is(response.status, 200);
 	t.is(content, text);
 });
+
+test('error for request with malformed URI', async t => {
+	const url = await getUrl();
+	const response = await fetch(`${url}/%E0%A4%A`);
+	const text = await response.text();
+
+	t.is(response.status, 400);
+
+	const content = errorTemplate({
+		statusCode: 400,
+		message: 'Bad Request'
+	});
+
+	t.is(text, content);
+});
+


### PR DESCRIPTION
Previously, requests like `/%E0%A4%A` caused a 500 instead of a 400:

```
{ URIError: URI malformed
    at decodeURIComponent (<anonymous>)
    at module.exports (/usr/src/app/node_modules/serve-handler/src/index.js:493:23)
    at trackStatusCodes (/usr/src/app/src/index.js:143:40)
    at /usr/src/app/node_modules/@zeit/metrics/http-status.js:20:10
    at module.exports.apiErrors (/usr/src/app/src/index.js:248:5)
    at <anonymous>
  [stack]: 'URIError: URI malformed\n    at decodeURIComponent (<anonymous>)\n    at module.exports (/usr/src/app/node_modules/serve-handler/src/index.js:493:23)\n    at trackStatusCodes (/usr/src/app/src/index.js:143:40)\n    at /usr/src/app/node_modules/@zeit/metrics/http-status.js:20:10\n    at module.exports.apiErrors (/usr/src/app/src/index.js:248:5)\n    at <anonymous>',
  [message]: 'URI malformed' }
```

Now they cause a proper 400.