### PR TITLE
Allow custom headers to be set for default error responses

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -473,11 +473,9 @@ const sendError = async (absolutePath, response, acceptsJSON, current, handlers,
 	}
 
 	const headers = await getHeaders(config.headers, current, absolutePath, null);
+	headers['Content-Type'] = 'text/html; charset=utf-8';
 
-	response.writeHead(statusCode, Object.assign(headers, {
-		'Content-Type': 'text/html; charset=utf-8'
-	}));
-
+	response.writeHead(statusCode, headers);
 	response.end(errorTemplate({statusCode, message}));
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -192,21 +192,25 @@ const getHeaders = async (customHeaders = [], current, absolutePath, stats) => {
 		}
 	}
 
-	const defaultHeaders = {
-		'Last-Modified': stats.mtime.toUTCString(),
-		'Content-Length': stats.size,
-		// Default to "inline", which always tries to render in the browser,
-		// if that's not working, it will save the file. But to be clear: This
-		// only happens if it cannot find a appropiate value.
-		'Content-Disposition': contentDisposition(base, {
-			type: 'inline'
-		})
-	};
+	let defaultHeaders = {};
 
-	const contentType = mime.contentType(base);
+	if (stats) {
+		defaultHeaders = {
+			'Last-Modified': stats.mtime.toUTCString(),
+			'Content-Length': stats.size,
+			// Default to "inline", which always tries to render in the browser,
+			// if that's not working, it will save the file. But to be clear: This
+			// only happens if it cannot find a appropiate value.
+			'Content-Disposition': contentDisposition(base, {
+				type: 'inline'
+			})
+		};
 
-	if (contentType) {
-		defaultHeaders['Content-Type'] = contentType;
+		const contentType = mime.contentType(base);
+
+		if (contentType) {
+			defaultHeaders['Content-Type'] = contentType;
+		}
 	}
 
 	return Object.assign(defaultHeaders, related);
@@ -422,7 +426,7 @@ const renderDirectory = async (current, acceptsJSON, handlers, methods, config, 
 	return {directory: output};
 };
 
-const sendError = async (response, acceptsJSON, current, handlers, config, spec) => {
+const sendError = async (absolutePath, response, acceptsJSON, current, handlers, config, spec) => {
 	const {err: original, message, code, statusCode} = spec;
 
 	/* istanbul ignore next */
@@ -454,7 +458,7 @@ const sendError = async (response, acceptsJSON, current, handlers, config, spec)
 	} catch (err) {
 		if (err.code !== 'ENOENT') {
 			// eslint-disable-next-line no-use-before-define
-			return internalError(response, acceptsJSON, current, handlers, config, err);
+			return internalError(absolutePath, response, acceptsJSON, current, handlers, config, err);
 		}
 	}
 
@@ -468,7 +472,12 @@ const sendError = async (response, acceptsJSON, current, handlers, config, spec)
 		return;
 	}
 
-	response.setHeader('Content-Type', 'text/html; charset=utf-8');
+	const headers = await getHeaders(config.headers, current, absolutePath, null);
+
+	response.writeHead(statusCode, Object.assign(headers, {
+		'Content-Type': 'text/html; charset=utf-8'
+	}));
+
 	response.end(errorTemplate({statusCode, message}));
 };
 
@@ -501,7 +510,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 	try {
 		relativePath = decodeURIComponent(url.parse(request.url).pathname);
 	} catch (err) {
-		return sendError(response, acceptsJSON, current, handlers, config, {
+		return sendError('/', response, acceptsJSON, current, handlers, config, {
 			statusCode: 400,
 			code: 'bad_request',
 			message: 'Bad Request'
@@ -513,7 +522,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 	// Prevent path traversal vulnerabilities. We could do this
 	// by ourselves, but using the package covers all the edge cases.
 	if (!isPathInside(absolutePath, current)) {
-		return sendError(response, acceptsJSON, current, handlers, config, {
+		return sendError(absolutePath, response, acceptsJSON, current, handlers, config, {
 			statusCode: 400,
 			code: 'bad_request',
 			message: 'Bad Request'
@@ -551,7 +560,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 			stats = await handlers.stat(absolutePath);
 		} catch (err) {
 			if (err.code !== 'ENOENT') {
-				return internalError(response, acceptsJSON, current, handlers, config, err);
+				return internalError(absolutePath, response, acceptsJSON, current, handlers, config, err);
 			}
 		}
 	}
@@ -567,7 +576,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 			}
 		} catch (err) {
 			if (err.code !== 'ENOENT') {
-				return internalError(response, acceptsJSON, current, handlers, config, err);
+				return internalError(absolutePath, response, acceptsJSON, current, handlers, config, err);
 			}
 		}
 	}
@@ -577,7 +586,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 			stats = await handlers.stat(absolutePath);
 		} catch (err) {
 			if (err.code !== 'ENOENT') {
-				return internalError(response, acceptsJSON, current, handlers, config, err);
+				return internalError(absolutePath, response, acceptsJSON, current, handlers, config, err);
 			}
 		}
 	}
@@ -599,7 +608,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 			}
 		} catch (err) {
 			if (err.code !== 'ENOENT') {
-				return internalError(response, acceptsJSON, current, handlers, config, err);
+				return internalError(absolutePath, response, acceptsJSON, current, handlers, config, err);
 			}
 		}
 
@@ -621,7 +630,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 	}
 
 	if (!stats) {
-		return sendError(response, acceptsJSON, current, handlers, config, {
+		return sendError(absolutePath, response, acceptsJSON, current, handlers, config, {
 			statusCode: 404,
 			code: 'not_found',
 			message: 'The requested path could not be found'

--- a/test/integration.js
+++ b/test/integration.js
@@ -972,3 +972,29 @@ test('error for request with malformed URI', async t => {
 	t.is(text, content);
 });
 
+test('error responses get custom headers', async t => {
+	const url = await getUrl({
+		'public': path.join(fixturesTarget, 'single-directory'),
+		'headers': [{
+			source: '**',
+			headers: [{
+				key: 'who',
+				value: 'me'
+			}]
+		}]
+	});
+
+	const response = await fetch(`${url}/non-existing`);
+	const text = await response.text();
+
+	t.is(response.status, 404);
+	t.is(response.headers.get('who'), 'me');
+
+	const content = errorTemplate({
+		statusCode: 404,
+		message: 'The requested path could not be found'
+	});
+
+	t.is(text, content);
+});
+


### PR DESCRIPTION
Previously, custom headers were not applied to all error responses, only for `.html` pages.

Once this is merged, they will also be applied to the default error renderings.