### PR TITLE
Support `sendError` as middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Just add a `<status-code>.html` file to the root directory and you're good.
 
 ## Middleware
 
-If you want to replace the methods the package is using for interacting with the file system, you can pass them as the fourth argument to the function call.
+If you want to replace the methods the package is using for interacting with the file system and sending responses, you can pass them as the fourth argument to the function call.
 
 These are the methods used by the package (they can all return a `Promise` or be asynchronous):
 
@@ -264,7 +264,8 @@ These are the methods used by the package (they can all return a `Promise` or be
 await handler(request, response, undefined, {
   stat(path) {},
   createReadStream(path) {},
-  readdir(path) {}
+  readdir(path) {},
+  sendError(absolutePath, response, acceptsJSON, root, handlers, config, error) {}
 });
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -630,10 +630,6 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 
 	if (!stats) {
 		// allow for custom 404 handling
-		const headers = await getHeaders(config.headers, current, absolutePath, stats);
-		Object.keys(headers).forEach(key => {
-			response.setHeader(key, headers[key]);
-		});
 		return handlers.sendError(absolutePath, response, acceptsJSON, current, handlers, config, {
 			statusCode: 404,
 			code: 'not_found',

--- a/src/index.js
+++ b/src/index.js
@@ -17,12 +17,6 @@ const isPathInside = require('path-is-inside');
 const directoryTemplate = require('./directory');
 const errorTemplate = require('./error');
 
-const getHandlers = methods => Object.assign({
-	stat: promisify(stat),
-	createReadStream: createReadStream,
-	readdir: promisify(readdir)
-}, methods);
-
 const sourceMatches = (source, requestPath, allowSegments) => {
 	const keys = [];
 	const slashed = slasher(source);
@@ -493,6 +487,13 @@ const internalError = async (...args) => {
 	return sendError(...args);
 };
 
+const getHandlers = methods => Object.assign({
+	stat: promisify(stat),
+	createReadStream,
+	readdir: promisify(readdir),
+	sendError
+}, methods);
+
 module.exports = async (request, response, config = {}, methods = {}) => {
 	const cwd = process.cwd();
 	const current = config.public ? path.join(cwd, config.public) : cwd;
@@ -628,7 +629,12 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 	}
 
 	if (!stats) {
-		return sendError(absolutePath, response, acceptsJSON, current, handlers, config, {
+		// allow for custom 404 handling
+		const headers = await getHeaders(config.headers, current, absolutePath, stats);
+		Object.keys(headers).forEach(key => {
+			response.setHeader(key, headers[key]);
+		});
+		return handlers.sendError(absolutePath, response, acceptsJSON, current, handlers, config, {
 			statusCode: 404,
 			code: 'not_found',
 			message: 'The requested path could not be found'


### PR DESCRIPTION
This allows send-handler to be combined with other servers (such as the
Next.js server) to provide a custom handler for unknown paths.