### PR TITLE
Handle `ETag` and `If-None-Match`

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Allows you to set custom headers (and overwrite the default ones) for certain pa
 }
 ```
 
+If you define the `ETag` header for a path, the handler will automatically reply with status code `304` for that path if a request comes in with a matching `If-None-Match` header.
+
 **NOTE:** The paths can only contain globs that are matched using [minimatch](https://github.com/isaacs/minimatch).
 
 ### directoryListing (Boolean|Array)

--- a/src/index.js
+++ b/src/index.js
@@ -642,7 +642,9 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 
 	// We need to check for `headers.ETag` being truthy first, otherwise it will
 	// match `undefined` being equal to `undefined`, which is true.
-	if (!request.headers.range && headers.ETag && headers.ETag === request.headers['if-none-match']) {
+	//
+	// eslint-disable-next-line no-eq-null
+	if (request.headers.range == null && headers.ETag && headers.ETag === request.headers['if-none-match']) {
 		response.statusCode = 304;
 		response.end();
 

--- a/src/index.js
+++ b/src/index.js
@@ -643,6 +643,8 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 	// We need to check for `headers.ETag` being truthy first, otherwise it will
 	// match `undefined` being equal to `undefined`, which is true.
 	//
+	// Checking for `undefined` and `null` is also important, because `Range` can be `0`.
+	//
 	// eslint-disable-next-line no-eq-null
 	if (request.headers.range == null && headers.ETag && headers.ETag === request.headers['if-none-match']) {
 		response.statusCode = 304;

--- a/src/index.js
+++ b/src/index.js
@@ -640,6 +640,8 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 	const stream = await handlers.createReadStream(absolutePath);
 	const headers = await getHeaders(config.headers, current, absolutePath, stats);
 
+	// We need to check for `headers.ETag` being truthy first, otherwise it will
+	// match `undefined` being equal to `undefined`, which is true.
 	if (!request.headers.range && headers.ETag && headers.ETag === request.headers['if-none-match']) {
 		response.statusCode = 304;
 		response.end();

--- a/src/index.js
+++ b/src/index.js
@@ -640,6 +640,13 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 	const stream = await handlers.createReadStream(absolutePath);
 	const headers = await getHeaders(config.headers, current, absolutePath, stats);
 
+	if (!request.headers.range && headers.ETag && headers.ETag === request.headers['if-none-match']) {
+		response.statusCode = 304;
+		response.end();
+
+		return;
+	}
+
 	response.writeHead(response.statusCode || 200, headers);
 	stream.pipe(response);
 };


### PR DESCRIPTION
This adds native support for `304` responses for any path in the case that:

- A `ETag` header was set for that path
- A request comes in to that path with `If-None-Match` matching the previously sent `ETag`

Only if both are true, the `304` response will occur.