### PR TITLE
Only try range if size is accessible

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -649,7 +649,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 	const streamOpts = {};
 
 	// TODO ? if-range
-	if (request.headers.range) {
+	if (request.headers.range && stats.size) {
 		const range = parseRange(stats.size, request.headers.range);
 
 		if (typeof range === 'object' && range.type === 'bytes') {


### PR DESCRIPTION
In https://github.com/zeit/serve-handler/pull/40, we introduced support for HTTP range requests.

With this PR right here, we're making sure to only try retrieving a the range of a file if the `stat` call returns the `size` of the file.

If it doesn't, we need to fall back to sending the full file, not an error.