### PR TITLE
Allow to remove headers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -216,7 +216,15 @@ const getHeaders = async (customHeaders = [], current, absolutePath, stats) => {
 		}
 	}
 
-	return Object.assign(defaultHeaders, related);
+	const headers = Object.assign(defaultHeaders, related);
+
+	for (const key in headers) {
+		if (headers.hasOwnProperty(key) && headers[key] === null) {
+			delete headers[key];
+		}
+	}
+
+	return headers;
 };
 
 const applicable = (decodedPath, configEntry) => {

--- a/test/integration.js
+++ b/test/integration.js
@@ -1181,3 +1181,28 @@ test('range request not satisfiable', async t => {
 	const spec = content.toString();
 	t.is(text, spec);
 });
+
+test('remove header when null', async t => {
+	const key = 'Cache-Control';
+	const value = 'max-age=7200';
+
+	const list = [{
+		source: 'object.json',
+		headers: [{
+			key: key,
+			value: value
+		}, {
+			key: key,
+			value: null
+		}]
+	}];
+
+	const url = await getUrl({
+		headers: list
+	});
+
+	const {headers} = await fetch(`${url}/object.json`);
+	const cacheControl = headers.get(key);
+
+	t.falsy(cacheControl);
+});


### PR DESCRIPTION
This creates the opportunity to delete any header when the value is `null`.

Example below will remove the default `Content-Disposition`:

```json
{
  "headers": [
    {
      "source" : "**/*.*",
      "headers" : [{
        "key" : "Content-Disposition",
        "value" : null
      }]
    }]
}
```

Ref: zeit/serve#438