### PR TITLE
Fix `headers` example JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ Allows you to set custom headers (and overwrite the default ones) for certain pa
         "key" : "Cache-Control",
         "value" : "max-age=300"
       }]
-    }]
-  }
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
Removes an extraneous `}` from the `headers` example configuration.