### PR TITLE
Render file defined as index

### DIFF
--- a/test/fixtures/indexes-directory/index.htm
+++ b/test/fixtures/indexes-directory/index.htm
@@ -1,0 +1,1 @@
+index htm

--- a/test/fixtures/indexes-directory/index.html
+++ b/test/fixtures/indexes-directory/index.html
@@ -1,0 +1,1 @@
+index html

--- a/test/fixtures/indexes-directory/index.txt
+++ b/test/fixtures/indexes-directory/index.txt
@@ -1,0 +1,1 @@
+index txt

--- a/test/integration.js
+++ b/test/integration.js
@@ -1206,3 +1206,104 @@ test('remove header when null', async t => {
 
 	t.falsy(cacheControl);
 });
+
+test('render directory index (default index)', async t => {
+	const target = 'indexes-directory';
+	const index = path.join(fixturesFull, `${target}/index.html`);
+
+	const url = await getUrl({
+		cleanUrls: false,
+		renderIndex: true
+	});
+
+	const response = await fetch(`${url}/${target}`);
+	const content = await fs.readFile(index, 'utf8');
+	const text = await response.text();
+
+	t.is(content, text);
+});
+
+test('render directory index (string value)', async t => {
+	const target = 'indexes-directory';
+	const index = path.join(fixturesFull, `${target}/index.htm`);
+
+	const url = await getUrl({
+		cleanUrls: false,
+		renderIndex: 'index.htm'
+	});
+
+	const response = await fetch(`${url}/${target}`);
+	const content = await fs.readFile(index, 'utf8');
+	const text = await response.text();
+
+	t.is(content, text);
+});
+
+test('render directory index (specific)', async t => {
+	const target = 'indexes-directory';
+	const index = path.join(fixturesFull, `${target}/index.htm`);
+
+	const url = await getUrl({
+		cleanUrls: false,
+		renderIndex: ['index.htm']
+	});
+
+	const response = await fetch(`${url}/${target}`);
+	const content = await fs.readFile(index, 'utf8');
+	const text = await response.text();
+
+	t.is(content, text);
+});
+
+test('render directory index (priority element)', async t => {
+	const target = 'indexes-directory';
+	const index = path.join(fixturesFull, `${target}/index.txt`);
+
+	const url = await getUrl({
+		cleanUrls: false,
+		renderIndex: ['index.txt', 'index.htm', 'index.html']
+	});
+
+	const response = await fetch(`${url}/${target}`);
+	const content = await fs.readFile(index, 'utf8');
+	const text = await response.text();
+	const type = response.headers.get('content-type');
+
+	t.is(content, text);
+	t.is(type, 'text/plain; charset=utf-8');
+});
+
+test('render directory index (directoryListing=false and not index found)', async t => {
+	const target = 'indexes-directory';
+
+	const url = await getUrl({
+		cleanUrls: false,
+		directoryListing: false,
+		renderIndex: ['index', 'index.js', 'index.page']
+	});
+
+	const response = await fetch(`${url}/${target}`);
+	const type = response.headers.get('content-type');
+
+	t.is(type, 'text/html; charset=utf-8');
+	t.is(response.status, 404);
+});
+
+test('render directory index (directoryListing=true)', async t => {
+	const target = 'indexes-directory';
+	const listingContents = await getDirectoryContents(`${fixturesFull}/${target}`);
+
+	const url = await getUrl({
+		cleanUrls: false,
+		directoryListing: true,
+		renderIndex: ['index', 'index.js', 'index.page']
+	});
+
+	const response = await fetch(`${url}/${target}`);
+	const type = response.headers.get('content-type');
+	const text = await response.text();
+
+	t.is(type, 'text/html; charset=utf-8');
+	t.is(response.status, 200);
+	t.true(listingContents.every(item => text.includes(item)));
+});


### PR DESCRIPTION
I would like to suggest a feature for rendering a directory using a file defined as a index.

Example:

```js
// Using the default index: "index.html"
await handler(request, response, {
  renderIndex: true
});

// Defining a new index name
await handler(request, response, {
  renderIndex: 'index.html'
});

// Defining a list of file sorting by priority order
await handler(request, response, {
  renderIndex: ['index.htm', 'index.html', 'index.txt']
});
```

This is a way to "replace" the directory listing or set a file to render for a directory, similar to `renderSingle`.

Going to `/dir` will serve `/dir/index.html` by default when `renderIndex` is enabled.

Does this makes sense and fit into the purpose of the library?