### PR TITLE
Prevent errors from causing a crash loop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -468,8 +468,7 @@ const sendError = async (absolutePath, response, acceptsJSON, current, handlers,
 		stats = await handlers.stat(errorPage);
 	} catch (err) {
 		if (err.code !== 'ENOENT') {
-			// eslint-disable-next-line no-use-before-define
-			return internalError(absolutePath, response, acceptsJSON, current, handlers, config, err);
+			console.error(err);
 		}
 	}
 
@@ -478,17 +477,16 @@ const sendError = async (absolutePath, response, acceptsJSON, current, handlers,
 
 		try {
 			stream = await handlers.createReadStream(errorPage);
+
+			const headers = await getHeaders(config.headers, current, errorPage, stats);
+
+			response.writeHead(statusCode, headers);
+			stream.pipe(response);
+
+			return;
 		} catch (err) {
-			// eslint-disable-next-line no-use-before-define
-			return internalError(absolutePath, response, acceptsJSON, current, handlers, config, err);
+			console.error(err);
 		}
-
-		const headers = await getHeaders(config.headers, current, errorPage, stats);
-
-		response.writeHead(statusCode, headers);
-		stream.pipe(response);
-
-		return;
 	}
 
 	const headers = await getHeaders(config.headers, current, absolutePath, null);

--- a/test/integration.js
+++ b/test/integration.js
@@ -587,14 +587,12 @@ test('receive custom `404.html` error page', async t => {
 	t.is(text.trim(), '<span>Not Found</span>');
 });
 
-test('receive error because reading `404.html` failed', async t => {
-	const message = 'Internal Server Error';
-
+test('error is still sent back even if reading `404.html` failed', async t => {
 	// eslint-disable-next-line no-undefined
 	const url = await getUrl(undefined, {
 		stat: location => {
 			if (path.basename(location) === '404.html') {
-				throw new Error(message);
+				throw new Error('Any error occured while checking the file');
 			}
 
 			return fs.stat(location);
@@ -604,11 +602,11 @@ test('receive error because reading `404.html` failed', async t => {
 	const response = await fetch(`${url}/not-existing`);
 	const text = await response.text();
 
-	t.is(response.status, 500);
+	t.is(response.status, 404);
 
 	const content = errorTemplate({
-		statusCode: 500,
-		message: 'A server error has occurred'
+		statusCode: 404,
+		message: 'The requested path could not be found'
 	});
 
 	t.is(text, content);
@@ -1234,3 +1232,29 @@ test('errors in `createReadStream` get handled', async t => {
 	t.deepEqual(content, text);
 	t.deepEqual(response.status, 500);
 });
+
+test('log error when checking `404.html` failed', async t => {
+	// eslint-disable-next-line no-undefined
+	const url = await getUrl(undefined, {
+		createReadStream: (location, opts) => {
+			if (path.basename(location) === '404.html') {
+				throw new Error('Any error occured while checking the file');
+			}
+
+			return fs.createReadStream(location, opts);
+		}
+	});
+
+	const response = await fetch(`${url}/not-existing`);
+	const text = await response.text();
+
+	t.is(response.status, 404);
+
+	const content = errorTemplate({
+		statusCode: 404,
+		message: 'The requested path could not be found'
+	});
+
+	t.is(text, content);
+});
+


### PR DESCRIPTION
The coverage decreased in https://github.com/zeit/serve-handler/pull/56, this PR brings it back to 100%.

But most importantly, if an error occurs while reading an error template, we don't try to read the error template again, but instead just render the default text error.