### PR TITLE
Encode redirection targets properly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -556,7 +556,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 
 	if (redirect) {
 		response.writeHead(redirect.statusCode, {
-			Location: redirect.target
+			Location: encodeURIComponent(redirect.target)
 		});
 
 		response.end();

--- a/src/index.js
+++ b/src/index.js
@@ -556,7 +556,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 
 	if (redirect) {
 		response.writeHead(redirect.statusCode, {
-			Location: encodeURIComponent(redirect.target)
+			Location: encodeURI(redirect.target)
 		});
 
 		response.end();


### PR DESCRIPTION
Since we are decoding all incoming request paths [here](https://github.com/zeit/serve-handler/blob/22d4b00366a0d6776153352504262cd6bd5f393d/src/index.js#L533), we need to encode them again, in order to prevent Node.js from throwing an error when trying to send invalid headers.