### PR TITLE
Fix rewrites not working on Windows.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const errorTemplate = require('./error');
 const sourceMatches = (source, requestPath, allowSegments) => {
 	const keys = [];
 	const slashed = slasher(source);
-	const resolvedPath = path.resolve(requestPath);
+	const resolvedPath = path.posix.resolve(requestPath);
 
 	let results = null;
 


### PR DESCRIPTION
Fixes #77

path.resolve('/a') on windows will result in a path like 'C:\a' when using the win32 path implementation
