### PR TITLE
Disable symlinks by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ You can use any of the following options:
 | [`unlisted`](#unlisted-array)                        | Exclude paths from the directory listing                  |
 | [`trailingSlash`](#trailingslash-boolean)            | Remove or add trailing slashes to all paths               |
 | [`renderSingle`](#rendersingle-boolean)              | If a directory only contains one file, render it          |
+| [`symlinks`](#symlinks-boolean)                      | Resolve symlinks instead of rendering a 404 error         |
 
 ### public (String)
 
@@ -259,6 +260,20 @@ This is disabled by default and can be enabled like this:
 
 After that, if you access your directory `/test` (for example), you will see an image being rendered if the directory contains a single image file.
 
+### symlinks (Boolean)
+
+For security purposes, symlinks are disabled by default. If `serve-handler` encounters a symlink, it will treat it as if it doesn't exist in the first place. In turn, a 404 error is rendered for that path.
+
+However, this behavior can easily be adjusted:
+
+```js
+{
+  "symlinks": true
+}
+```
+
+Once this property is set as shown above, all symlinks will automatically be resolved to their targets.
+
 ## Error templates
 
 The handler will automatically determine the right error format if one occurs and then sends it to the client in that format.
@@ -275,7 +290,8 @@ These are the methods used by the package (they can all return a `Promise` or be
 
 ```js
 await handler(request, response, undefined, {
-  stat(path) {},
+  lstat(path) {},
+  realpath(path) {},
   createReadStream(path, config) {}
   readdir(path) {},
   sendError(absolutePath, response, acceptsJSON, root, handlers, config, error) {}

--- a/src/index.js
+++ b/src/index.js
@@ -667,6 +667,9 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 		});
 	}
 
+	// If we figured out that the target is a symlink, we need to
+	// resolve the symlink and run a new `stat` call just for the
+	// target of that symlink.
 	if (isSymLink) {
 		absolutePath = await handlers.realpath(absolutePath);
 		stats = await handlers.lstat(absolutePath);

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // Native
 const {promisify} = require('util');
 const path = require('path');
-const {stat, createReadStream, readdir} = require('fs');
+const {realpath, lstat, createReadStream, readdir} = require('fs');
 
 // Packages
 const url = require('fast-url-parser');
@@ -327,10 +327,10 @@ const renderDirectory = async (current, acceptsJSON, handlers, methods, config, 
 		// simulating those calls and needs to special-case this.
 		let stats = null;
 
-		if (methods.stat) {
-			stats = await handlers.stat(filePath, true);
+		if (methods.lstat) {
+			stats = await handlers.lstat(filePath, true);
 		} else {
-			stats = await handlers.stat(filePath);
+			stats = await handlers.lstat(filePath);
 		}
 
 		details.relative = path.join(relativePath, details.base);
@@ -466,7 +466,7 @@ const sendError = async (absolutePath, response, acceptsJSON, current, handlers,
 	const errorPage = path.join(current, `${statusCode}.html`);
 
 	try {
-		stats = await handlers.stat(errorPage);
+		stats = await handlers.lstat(errorPage);
 	} catch (err) {
 		if (err.code !== 'ENOENT') {
 			console.error(err);
@@ -512,7 +512,8 @@ const internalError = async (...args) => {
 };
 
 const getHandlers = methods => Object.assign({
-	stat: promisify(stat),
+	lstat: promisify(lstat),
+	realpath: promisify(realpath),
 	createReadStream,
 	readdir: promisify(readdir),
 	sendError
@@ -580,7 +581,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 
 	if (path.extname(relativePath) !== '') {
 		try {
-			stats = await handlers.stat(absolutePath);
+			stats = await handlers.lstat(absolutePath);
 		} catch (err) {
 			if (err.code !== 'ENOENT') {
 				return internalError(absolutePath, response, acceptsJSON, current, handlers, config, err);
@@ -592,7 +593,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 
 	if (!stats && (cleanUrl || rewrittenPath)) {
 		try {
-			const related = await findRelated(current, relativePath, rewrittenPath, handlers.stat);
+			const related = await findRelated(current, relativePath, rewrittenPath, handlers.lstat);
 
 			if (related) {
 				({stats, absolutePath} = related);
@@ -606,7 +607,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 
 	if (!stats) {
 		try {
-			stats = await handlers.stat(absolutePath);
+			stats = await handlers.lstat(absolutePath);
 		} catch (err) {
 			if (err.code !== 'ENOENT') {
 				return internalError(absolutePath, response, acceptsJSON, current, handlers, config, err);
@@ -652,13 +653,23 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 		}
 	}
 
-	if (!stats) {
+	const isSymLink = stats && stats.isSymbolicLink();
+
+	// There are two scenarios in which we want to reply with
+	// a 404 error: Either the path does not exist, or it is a
+	// symlink while the `symlinks` option is disabled (which it is by default).
+	if (!stats || (!config.symlinks && isSymLink)) {
 		// allow for custom 404 handling
 		return handlers.sendError(absolutePath, response, acceptsJSON, current, handlers, config, {
 			statusCode: 404,
 			code: 'not_found',
 			message: 'The requested path could not be found'
 		});
+	}
+
+	if (isSymLink) {
+		absolutePath = await handlers.realpath(absolutePath);
+		stats = await handlers.lstat(absolutePath);
 	}
 
 	const streamOpts = {};
@@ -669,6 +680,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 
 		if (typeof range === 'object' && range.type === 'bytes') {
 			const {start, end} = range[0];
+
 			streamOpts.start = start;
 			streamOpts.end = end;
 

--- a/test/fixtures/symlinks/package.json
+++ b/test/fixtures/symlinks/package.json
@@ -1,0 +1,1 @@
+../../../package.json


### PR DESCRIPTION
In order to prevent potential security issues, the team has decided to disable symlinks by default.

To enable them, you can define the `symlinks` option:

```js
{
   "symlinks": true
}
```

Furthermore, this pull request also adds a new handler for `fs.realpath`, which is responsible for resolving the target of symlinks if they are enabled.