### PR TITLE
Disable encoding on url segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,16 @@ You can also use so-called "routing segments" as follows:
 
 Now, if a visitor accesses `/projects/123/edit`, it will respond with the file `/edit-project-123.html`.
 
+Sometimes, the part of the URL that you will match might contain characters that you do not want to get encoded. In that case, you should add the `raw` option. You will also need to provide a RegExp for the routing segment. By default, characters like `/` are not allowed.
+
+```json
+{
+  "rewrites": [
+    { "source": "/projects/:file+", "destination": "/actual-projects/:file(.+)", "raw": true },
+  ]
+}
+```
+
 **NOTE:** The paths can contain globs (matched using [minimatch](https://github.com/isaacs/minimatch)) or regular expressions (match using [path-to-regexp](https://github.com/pillarjs/path-to-regexp)).
 
 ### redirects (Array)

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ const sourceMatches = (source, requestPath, allowSegments) => {
 	return null;
 };
 
-const toTarget = (source, destination, previousPath) => {
+const toTarget = (source, destination, previousPath, raw) => {
 	const matches = sourceMatches(source, previousPath, true);
 
 	if (!matches) {
@@ -68,7 +68,7 @@ const toTarget = (source, destination, previousPath) => {
 		props[name] = results[index + 1];
 	}
 
-	return toPath(props);
+	return toPath(props, raw ? {encode: value => value} : {});
 };
 
 const applyRewrites = (requestPath, rewrites = [], repetitive) => {
@@ -84,8 +84,8 @@ const applyRewrites = (requestPath, rewrites = [], repetitive) => {
 	}
 
 	for (let index = 0; index < rewritesCopy.length; index++) {
-		const {source, destination} = rewrites[index];
-		const target = toTarget(source, destination, requestPath);
+		const {source, destination, raw} = rewrites[index];
+		const target = toTarget(source, destination, requestPath, raw);
 
 		if (target) {
 			// Remove rules that were already applied

--- a/test/integration.js
+++ b/test/integration.js
@@ -349,6 +349,24 @@ test('set `rewrites` config property to path segment', async t => {
 	t.deepEqual(json, content);
 });
 
+test('rewriting to a segment containing slashes', async t => {
+	const related = path.join(fixturesFull, 'single-directory', 'content.txt');
+	const content = await fs.readFile(related, 'utf8');
+
+	const url = await getUrl({
+		rewrites: [{
+			source: 'face/:file+',
+			destination: ':file(.+)',
+			raw: true
+		}]
+	});
+
+	const response = await fetch(`${url}/face/single-directory/content.txt`);
+	const text = await response.text();
+
+	t.is(text, content);
+});
+
 test('set `redirects` config property to wildcard path', async t => {
 	const destination = 'testing';
 


### PR DESCRIPTION
I was trying to rewrite all urls that looked like a/b/:path+ to c/d/:path, so in practice:

`a/b/file` => `c/d/file`
`a/b/dir/dir/dir/file` => `c/d/dir/dir/file`

However, it didn't work. After some digging I found that path-to-regexp was encoding the slashes in the matched url segment.

However, you can pass a custom encoder, so I've added an option on rewrite objects to use an identity function (`value => value`), so no character gets encoded in the URL. I've named it `raw` but I'm open to suggestions.

There's a minor detail, you also have to provide the regex for the destintation, because by default they disallow certain characters there as well. I've added an example to the README mentioning this too. Also, a small test case.

