### PR TITLE
Using posix path resolution. Resolves serve issue #525

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const errorTemplate = require('./error');
 const sourceMatches = (source, requestPath, allowSegments) => {
 	const keys = [];
 	const slashed = slasher(source);
-	const resolvedPath = path.resolve(requestPath);
+	const resolvedPath = path.posix.resolve(requestPath);
 
 	let results = null;
 


### PR DESCRIPTION
Resolves https://github.com/zeit/serve/issues/525

`path.resolve('/some-url')` returns `C:\\some-url` in Windows. Which breaks rewrites and makes the serve `--single` option not work in windows.

Using path.posix gives us linux/unix/posix functionality for resolving the path, which preserves the security fix that was added in https://github.com/zeit/serve-handler/pull/76 while still working in Windows.

I have verified that the `--single` option works with my changes, in both Windows 10 and Mac.