### PR TITLE
Include file path in `ETag` header generation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const etags = new Map();
 const calculateSha = (handlers, absolutePath) =>
 	new Promise((resolve, reject) => {
 		const hash = createHash('sha1');
-		hash.update(absolutePath);
+		hash.update(path.extname(absolutePath));
 		hash.update('-');
 		const rs = handlers.createReadStream(absolutePath);
 		rs.on('error', reject);

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ const etags = new Map();
 const calculateSha = (handlers, absolutePath) =>
 	new Promise((resolve, reject) => {
 		const hash = createHash('sha1');
+		hash.update(absolutePath);
+		hash.update('-');
 		const rs = handlers.createReadStream(absolutePath);
 		rs.on('error', reject);
 		rs.on('data', buf => hash.update(buf));

--- a/test/fixtures/docs.txt
+++ b/test/fixtures/docs.txt
@@ -1,0 +1,1 @@
+## This is a markdown file

--- a/test/integration.js
+++ b/test/integration.js
@@ -1340,13 +1340,13 @@ test('etag header is set', async t => {
 	t.is(response.status, 200);
 	t.is(
 		response.headers.get('etag'),
-		'"f636be8ebeec6d60536a00a9d197843becfdd0c6"'
+		'"60be4422531fce1513df34cbcc90bed5915a53ef"'
 	);
 
 	response = await fetch(`${url}/docs.txt`);
 	t.is(response.status, 200);
 	t.is(
 		response.headers.get('etag'),
-		'"6658be9c345e8b79034c781e555c15a38302bc2c"'
+		'"ba114dbc69e41e180362234807f093c3c4628f90"'
 	);
 });

--- a/test/integration.js
+++ b/test/integration.js
@@ -1331,14 +1331,22 @@ test('allow symlinks by setting the option', async t => {
 });
 
 test('etag header is set', async t => {
-	const directory = 'single-directory';
 	const url = await getUrl({
 		renderSingle: true,
 		etag: true
 	});
-	const response = await fetch(`${url}/${directory}`);
+
+	let response = await fetch(`${url}/docs.md`);
+	t.is(response.status, 200);
 	t.is(
 		response.headers.get('etag'),
-		'"4e5f19df3bfe8db7d588edfc3960991aa0715ccf"'
+		'"f636be8ebeec6d60536a00a9d197843becfdd0c6"'
+	);
+
+	response = await fetch(`${url}/docs.txt`);
+	t.is(response.status, 200);
+	t.is(
+		response.headers.get('etag'),
+		'"6658be9c345e8b79034c781e555c15a38302bc2c"'
 	);
 });


### PR DESCRIPTION
This is so that an index file that has its file extension changed is properly invalidated by the browser so that the changed `Content-Type` header is respected.