### PR TITLE
Enable support for slashes in regex when doing a rewrite.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ const applyRewrites = (requestPath, rewrites = [], repetitive) => {
 	const fallback = repetitive ? requestPath : null;
 
 	if (rewritesCopy.length === 0) {
-		return fallback;
+		return decodeURIComponent(fallback);
 	}
 
 	for (let index = 0; index < rewritesCopy.length; index++) {


### PR DESCRIPTION
`serve.json`: 
```{
    "rewrites": [
        {
            "source": "foo/:rest*",
            "destination": "/:rest*"
        }
    ]
}```

If we were to query `localhost:5000/foo/bar/quz/cux.json` `fallback` would end up being `/bar%2Fquz%2Fcux.json` which is never found by the `stat` function. 

This commit fixes that. 

Why did I do this? 

I have a site hosted at `http://foo.com/bar`, which is actually a reverse proxy. So my `zeit/serve` doesn't know that it's supposed to discard `bar`, as it thinks it's at the root. 

Now with the rewrite, that is fixed. 