### PR TITLE
Add rendering of modified date in directory listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ You can use any of the following options:
 | [`redirects`](#redirects-array)                      | Forward paths to different paths or external URLs                     |
 | [`headers`](#headers-array)                          | Set custom headers for specific paths                                 |
 | [`directoryListing`](#directorylisting-booleanarray) | Disable directory listing or restrict it to certain paths             |
+| [`renderModifiedDate`](#rendermodifieddate-boolean)  | Show modified date for files in directory listing                     |
 | [`unlisted`](#unlisted-array)                        | Exclude paths from the directory listing                              |
 | [`trailingSlash`](#trailingslash-boolean)            | Remove or add trailing slashes to all paths                           |
 | [`renderSingle`](#rendersingle-boolean)              | If a directory only contains one file, render it                      |
@@ -215,6 +216,18 @@ If you'd like to disable this for all paths, set this option to `false`. Further
 ```
 
 **NOTE:** The paths can only contain globs that are matched using [minimatch](https://github.com/isaacs/minimatch).
+
+### renderModifiedDate (Boolean)
+
+Render the modified date of a file next to its filename when listing a directory.
+
+This is disabled by default. To enable set `renderModifiedDate` to `true`:
+
+```js
+{
+  "renderModifiedDate": true
+}
+```
 
 ### unlisted (Array)
 

--- a/src/directory.jst
+++ b/src/directory.jst
@@ -150,7 +150,10 @@
       <ul id="files">
         {{~it.files :value:index}}
           <li>
-            <a href="{{!value.relative}}" title="{{!value.title}}" class="{{!value.type}} {{!value.ext}}">{{!value.base}}</a>
+            <a href="{{!value.relative}}" title="{{!value.title}}" class="{{!value.type}} {{!value.ext}}">{{!value.base}}</a> 
+            {{?value.mtime}}
+                <small>{{!value.mtime}}</small>
+            {{?}}
           </li>
         {{~}}
       </ul>

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 const {promisify} = require('util');
 const path = require('path');
 const {createHash} = require('crypto');
-const {realpath, lstat, createReadStream, readdir} = require('fs');
+const {realpath, lstat, createReadStream, readdir, stat} = require('fs');
 
 // Packages
 const url = require('fast-url-parser');
@@ -326,7 +326,7 @@ const canBeListed = (excluded, file) => {
 };
 
 const renderDirectory = async (current, acceptsJSON, handlers, methods, config, paths) => {
-	const {directoryListing, trailingSlash, unlisted = [], renderSingle} = config;
+	const {directoryListing, trailingSlash, unlisted = [], renderSingle, renderModifiedDate} = config;
 	const slashSuffix = typeof trailingSlash === 'boolean' ? (trailingSlash ? '/' : '') : '/';
 	const {relativePath, absolutePath} = paths;
 
@@ -383,6 +383,11 @@ const renderDirectory = async (current, acceptsJSON, handlers, methods, config, 
 				unitSeparator: ' ',
 				decimalPlaces: 0
 			});
+			if (renderModifiedDate) {
+				const fileStats = await handlers.stat(path.join(absolutePath, file));
+
+				details.mtime = fileStats.mtime.toLocaleString();
+			}
 		}
 
 		details.title = details.base;
@@ -544,6 +549,7 @@ const getHandlers = methods => Object.assign({
 	realpath: promisify(realpath),
 	createReadStream,
 	readdir: promisify(readdir),
+	stat: promisify(stat),
 	sendError
 }, methods);
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -55,6 +55,7 @@ test('render html directory listing', async t => {
 
 	t.is(type, 'text/html; charset=utf-8');
 	t.true(contents.every(item => text.includes(item)));
+	t.falsy(contents.every(() => text.match(/\<small\>([12]\d{3})-/gm)));
 });
 
 test('render json directory listing', async t => {
@@ -357,7 +358,7 @@ test('set `redirects` config property to wildcard path', async t => {
 			source: 'face/**',
 			destination
 		}]
-	 });
+	});
 
 	const response = await fetch(`${url}/face/mask`, {
 		redirect: 'manual',
@@ -376,7 +377,7 @@ test('set `redirects` config property to a negated wildcard path', async t => {
 			source: '!face/**',
 			destination
 		}]
-	 });
+	});
 
 	const responseTruthy = await fetch(`${url}/test/mask`, {
 		redirect: 'manual',
@@ -403,7 +404,7 @@ test('set `redirects` config property to wildcard path and do not match', async 
 			source: 'face/**',
 			destination
 		}]
-	 });
+	});
 
 	const response = await fetch(`${url}/test/mask`, {
 		redirect: 'manual',
@@ -422,7 +423,7 @@ test('set `redirects` config property to one-star wildcard path', async t => {
 			source: 'face/*/ideal',
 			destination
 		}]
-	 });
+	});
 
 	const response = await fetch(`${url}/face/mask/ideal`, {
 		redirect: 'manual',
@@ -441,7 +442,7 @@ test('set `redirects` config property to extglob wildcard path', async t => {
 			source: 'face/+(mask1|mask2)/ideal',
 			destination
 		}]
-	 });
+	});
 
 	const response = await fetch(`${url}/face/mask1/ideal`, {
 		redirect: 'manual',
@@ -458,7 +459,7 @@ test('set `redirects` config property to path segment', async t => {
 			source: 'face/:segment',
 			destination: 'mask/:segment'
 		}]
-	 });
+	});
 
 	const response = await fetch(`${url}/face/me`, {
 		redirect: 'manual',
@@ -478,7 +479,7 @@ test('set `redirects` config property to wildcard path and `trailingSlash` to `t
 			source: 'face/**',
 			destination: 'testing'
 		}]
-	 });
+	});
 
 	const response = await fetch(url + target, {
 		redirect: 'manual',
@@ -498,7 +499,7 @@ test('set `redirects` config property to wildcard path and `trailingSlash` to `f
 			source: 'face/**',
 			destination: 'testing'
 		}]
-	 });
+	});
 
 	const response = await fetch(`${url + target}/`, {
 		redirect: 'manual',
@@ -904,6 +905,40 @@ test('set `unlisted` config property to array', async t => {
 	});
 
 	t.true(existing);
+});
+
+test('set `renderModifiedDate` config property to `true`', async t => {
+	const name = 'special-directory';
+
+	const sub = path.join(fixturesFull, name);
+	const contents = await getDirectoryContents(sub, true);
+	const url = await getUrl({
+		renderModifiedDate: true
+	});
+	const response = await fetch(`${url}/${name}`);
+	const text = await response.text();
+
+	const type = response.headers.get('content-type');
+	t.is(type, 'text/html; charset=utf-8');
+	// Match to Year
+	t.true(contents.every(() => text.match(/\<small\>([12]\d{3})-/gm)));
+});
+
+test('set `renderModifiedDate` config property to `false`', async t => {
+	const name = 'special-directory';
+
+	const sub = path.join(fixturesFull, name);
+	const contents = await getDirectoryContents(sub, true);
+	const url = await getUrl({
+		renderModifiedDate: false
+	});
+	const response = await fetch(`${url}/${name}`);
+	const text = await response.text();
+
+	const type = response.headers.get('content-type');
+	t.is(type, 'text/html; charset=utf-8');
+	// Match to Year
+	t.falsy(contents.every(() => text.match(/\<small\>([12]\d{3})-/gm)));
 });
 
 test('set `createReadStream` handler to async function', async t => {


### PR DESCRIPTION
This adds the modified date timestamp `details.mtime` to files. The timestamp gets rendered in directory listings. This is disabled by default but can be enabled by the new boolean option `renderModifiedDate`.

 This is quite useful for a project that I'm working on where we `serve` a lots of screenshots that are generated during end-to-end testing. Please let me know if additional changes are needed, I'd be happy to address any concerns.

### In JSON response:

```json
{
  "files": [
    {
      "type": "directory",
      "base": "..",
      "relative": "/",
      "title": "/",
      "ext": ""
    },
    {
      "root": "/",
      "dir": "/home/moritz/dev/serve-handler/test/fixtures/single-directory",
      "base": "content.txt",
      "ext": "txt",
      "name": "content",
      "relative": "/single-directory/content.txt",
      "type": "file",
      "size": "19 B",
      "mtime": "2019-8-30 8:00:00 AM",
      "title": "content.txt"
    }
  ],
}
```


### In HTML Render:

![2020-01-17_16-22-21-screenshot](https://user-images.githubusercontent.com/22394314/72624736-c0e64880-3947-11ea-9393-64eee41eab91.png)
